### PR TITLE
add browser specific version

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -1,4 +1,5 @@
-var WritableStream = require('stream').Writable;
+var WritableStream = require('stream-browserify').Writable;
 var createBlobStream = require('./create-blob-stream');
 
 module.exports = createBlobStream(WritableStream);
+

--- a/create-blob-stream.js
+++ b/create-blob-stream.js
@@ -1,0 +1,50 @@
+var inherits = require("inherits");
+var Blob = require("blob");
+var URL = global.URL || global.webkitURL || global.mozURL;
+
+function createBlobStream(WritableStream) {
+  function BlobStream() {
+    if (!(this instanceof BlobStream)) return new BlobStream();
+
+    WritableStream.call(this);
+    this._chunks = [];
+    this._blob = null;
+    this.length = 0;
+  }
+
+  inherits(BlobStream, WritableStream);
+
+  BlobStream.prototype._write = function (chunk, encoding, callback) {
+    // convert chunks to Uint8Arrays (e.g. Buffer when array fallback is being used)
+    if (!(chunk instanceof Uint8Array)) chunk = new Uint8Array(chunk);
+
+    this.length += chunk.length;
+    this._chunks.push(chunk);
+    callback();
+  };
+
+  BlobStream.prototype.toBlob = function (type) {
+    type = type || "application/octet-stream";
+
+    // cache the blob if needed
+    if (!this._blob) {
+      this._blob = new Blob(this._chunks, {
+        type: type,
+      });
+
+      this._chunks = []; // free memory
+    }
+
+    // if the cached blob's type doesn't match the requested type, make a new blob
+    if (this._blob.type !== type) this._blob = new Blob([this._blob], { type: type });
+
+    return this._blob;
+  };
+
+  BlobStream.prototype.toBlobURL = function (type) {
+    return URL.createObjectURL(this.toBlob(type));
+  };
+  return BlobStream;
+}
+
+module.exports = createBlobStream;

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.3",
   "description": "A Node-style writable stream for HTML5 Blobs",
   "main": "index.js",
+  "browser": "browser.js",
   "directories": {
     "test": "test"
   },
@@ -21,7 +22,9 @@
   },
   "homepage": "https://github.com/devongovett/blob-stream",
   "dependencies": {
-    "blob": "0.0.4"
+    "blob": "0.0.4",
+    "inherits": "^2.0.4",
+    "stream-browserify": "^3.0.0"
   },
   "devDependencies": {
     "tape": "^2.12.3"


### PR DESCRIPTION
Closes #6 

Not sure if this is the best approach. I tried to keep the changes to a minimum. I resolved the dependency on module "stream" by depending on ["stream-browserify"](https://www.npmjs.com/package/stream-browserify) and the dependency on "util" by using the ["inherits"](https://www.npmjs.com/package/inherits)-packages (which is also used by stream-browserify, see [package.json](https://github.com/browserify/stream-browserify/blob/a3625cb4181c4bcdf09884e677d4320c641b8724/package.json#L7)).
